### PR TITLE
README Updates: Simplify getting started, add CQL snippet, add repo details to intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ querying of FHIR via FHIRPath, graceful handling of mixed precision or missing
 data and built in clinical helper functions. You can find an intro to the CQL
 Language at https://cql.hl7.org.
 
+This repository contains an experimental CQL execution engine in Go, along
+with various supporting tools and ecosystem connectors. See the 
+[Getting Started](#getting-started) section to get up and running quickly.
+
+Here's a CQL example:
+<div align="center">
+<img width="600" src="https://github.com/google/cql/assets/6299853/c4761a19-924c-4534-bd61-a95d5101a308"/>
+</div>
+
 ## Features
 
 Notable features of this engine include:
@@ -54,46 +63,26 @@ Language:
 
 ## Getting Started
 
-There are several different ways to use this engine. For quick experimentation
-we have a Command Line Interface and REPL. For executing CQL over a large
-patient population there is a Beam job. Finally, the CQL Golang Module allows
-you to execute CQL by implementing your own connector to a database and
-terminology server.
+**⚠️ Warning: When using these tools with protected health information (PHI), please be sure
+to follow your organization's policies with respect to PHI.**
 
-> ⚠️⚠️  **Warning**  ⚠️⚠️
->
-> When using these tools with protected health information (PHI), please be sure
-to follow your organization's policies with respect to PHI.
+There are several different ways to use this CQL engine, and get up and running quickly. 
+Click on the links below for details:
 
-## Web Playground
-To quickly experiment with the CQL engine and editable FHIR data, try our local
-web playground in the browser at [cmd/cqlplay](cmd/cqlplay).
-
-## CLI
-
-When intending to run the CQL engine locally over small populations or for quick
-experimentation use the CLI located at [cmd/cli](cmd/cli). For documentation
-and examples see [cmd/cli/README.md](cmd/cli/README.md).
-
-## Apache Beam Pipeline
-
-The Beam pipeline is recommended when running CQL over large patient populations.
-More information and usage examples are documented at
-[beam/README.md](beam/README.md).
-
-## Golang Module
-
-The engine can be used via the CQL golang module documented in the
+* [__Web Playground__](cmd/cqlplay/README.md): A local interactive web playground
+  in the browser (with editable FHIR data), to quickly experiment with our CQL
+  engine.
+* [__CLI__](cmd/cli/README.md): A command-line interface to run this CQL engine
+  over small populations or for quick experimentation.
+* [__Apache Beam__](): The Beam pipeline is recommended when running CQL over
+  large patient populations.
+* [__REPL__](): For quick experiments with our CQL Engine we have a REPL.
+* [__Golang Module__](): The engine can be used via the CQL golang module documented in the
 [godoc](https://pkg.go.dev/github.com/google/cql).
 The [Retriever interface](retriever/retriever.go) can be implemented to connect
 to a custom database or FHIR server. The
 [Terminology Provider interface](terminology/provider.go) can be implemented to
 connect to a custom Terminology server.
-
-## REPL
-
-For quick experiments with our CQL Engine we have a REPL. More information and
-usage examples are documented at [cmd/repl/README.md](cmd/repl/README.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ scale</p>
   </p>
 </p>
 
-
-
 CQL is a domain specific language designed for querying and executing logic on
 healthcare data. CQL excels at healthcare data analysis such as defining quality
 measures, clinical decision support, cohorts or preparing data for dashboards.
@@ -22,9 +20,9 @@ This repository contains an experimental CQL execution engine in Go, along
 with various supporting tools and ecosystem connectors. See the 
 [Getting Started](#getting-started) section to get up and running quickly.
 
-Here's a CQL example:
 <div align="center">
-<img width="600" src="https://github.com/google/cql/assets/6299853/c4761a19-924c-4534-bd61-a95d5101a308"/>
+  <img width="600" src="https://github.com/google/cql/assets/6299853/f11cbde5-9a44-41ea-847d-1de20e327306"/>
+  <p><i>A CQL example snippet.</i></p>
 </div>
 
 ## Features
@@ -70,8 +68,8 @@ There are several different ways to use this CQL engine, and get up and running 
 Click on the links below for details:
 
 * [__Web Playground__](cmd/cqlplay/README.md): A local interactive web playground
-  in the browser (with editable FHIR data), to quickly experiment with our CQL
-  engine.
+  in the browser, to quickly experiment with our CQL engine. Includes CQL syntax
+  highlighting and a basic FHIR editor.
 * [__CLI__](cmd/cli/README.md): A command-line interface to run this CQL engine
   over small populations or for quick experimentation.
 * [__Apache Beam__](): The Beam pipeline is recommended when running CQL over

--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ Language:
 
 ## Getting Started
 
-**⚠️ Warning: When using these tools with protected health information (PHI), please be sure
-to follow your organization's policies with respect to PHI. ⚠️**
-
 There are several different ways to use this CQL engine, and get up and running quickly.
 Click on the links below for details:
 
@@ -81,6 +78,9 @@ Click on the links below for details:
   to a custom database or FHIR server. The
   [Terminology Provider interface](terminology/provider.go) can be implemented to
   connect to a custom Terminology server.
+
+**⚠️ Warning: When using these tools with protected health information (PHI), please be sure
+to follow your organization's policies with respect to PHI. ⚠️**
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ data and built in clinical helper functions. You can find an intro to the CQL
 Language at https://cql.hl7.org.
 
 This repository contains an experimental CQL execution engine in Go, along
-with various supporting tools and ecosystem connectors. See the 
+with various supporting tools and ecosystem connectors. See the
 [Getting Started](#getting-started) section to get up and running quickly.
 
 <div align="center">
@@ -62,9 +62,9 @@ Language:
 ## Getting Started
 
 **⚠️ Warning: When using these tools with protected health information (PHI), please be sure
-to follow your organization's policies with respect to PHI.**
+to follow your organization's policies with respect to PHI. ⚠️**
 
-There are several different ways to use this CQL engine, and get up and running quickly. 
+There are several different ways to use this CQL engine, and get up and running quickly.
 Click on the links below for details:
 
 * [__Web Playground__](cmd/cqlplay/README.md): A local interactive web playground
@@ -74,9 +74,9 @@ Click on the links below for details:
   over small populations or for quick experimentation.
 * [__Apache Beam__](beam/README.md): The Beam pipeline is recommended when running CQL over
   large patient populations.
-* [__REPL__](cmd/repl/README.md): For quick experiments with our CQL Engine we have a REPL.
-* [__Golang Module__](https://pkg.go.dev/github.com/google/cql): The engine can be
-  used via the CQL golang module documented in the [godoc](https://pkg.go.dev/github.com/google/cql).
+* [__REPL__](cmd/repl/README.md): An interactive command line REPL for quick CQL explorations and experiments.
+* [__Golang Module__](https://pkg.go.dev/github.com/google/cql): The CQL execution engine can be
+  used as a Go library via the [CQL golang module](https://pkg.go.dev/github.com/google/cql).
   The [Retriever interface](retriever/retriever.go) can be implemented to connect
   to a custom database or FHIR server. The
   [Terminology Provider interface](terminology/provider.go) can be implemented to

--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ Click on the links below for details:
   highlighting and a basic FHIR editor.
 * [__CLI__](cmd/cli/README.md): A command-line interface to run this CQL engine
   over small populations or for quick experimentation.
-* [__Apache Beam__](): The Beam pipeline is recommended when running CQL over
+* [__Apache Beam__](beam/README.md): The Beam pipeline is recommended when running CQL over
   large patient populations.
-* [__REPL__](): For quick experiments with our CQL Engine we have a REPL.
-* [__Golang Module__](): The engine can be used via the CQL golang module documented in the
-[godoc](https://pkg.go.dev/github.com/google/cql).
-The [Retriever interface](retriever/retriever.go) can be implemented to connect
-to a custom database or FHIR server. The
-[Terminology Provider interface](terminology/provider.go) can be implemented to
-connect to a custom Terminology server.
+* [__REPL__](cmd/repl/README.md): For quick experiments with our CQL Engine we have a REPL.
+* [__Golang Module__](https://pkg.go.dev/github.com/google/cql): The engine can be
+  used via the CQL golang module documented in the [godoc](https://pkg.go.dev/github.com/google/cql).
+  The [Retriever interface](retriever/retriever.go) can be implemented to connect
+  to a custom database or FHIR server. The
+  [Terminology Provider interface](terminology/provider.go) can be implemented to
+  connect to a custom Terminology server.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ with various supporting tools and ecosystem connectors. See the
 
 <div align="center">
   <img width="600" src="https://github.com/google/cql/assets/6299853/f11cbde5-9a44-41ea-847d-1de20e327306"/>
-  <p><i>A CQL example snippet.</i></p>
+  <p><i>An example CQL snippet.</i></p>
 </div>
 
 ## Features

--- a/beam/README.md
+++ b/beam/README.md
@@ -10,6 +10,9 @@ sharding datasets, and other such tasks. See these
 [docs](https://cloud.google.com/dataflow/docs/concepts/beam-programming-model)
 for more information on Apache Beam.
 
+**Warning: When using these tools with protected health information (PHI),
+please be sure to follow your organization's policies with respect to PHI.**
+
 ## Running
 
 The CQL on Beam pipeline is currently limited to local file system IO. The

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -7,6 +7,9 @@ The CLI is primarily designed for executing single patient or small population
 workflows. For larger population sets the scalable beam job is a more
 appropriate solution.
 
+**Warning: When using these tools with protected health information (PHI),
+please be sure to follow your organization's policies with respect to PHI.**
+
 ## Running
 
 To build the program from source run the following from the root of the

--- a/cmd/repl/README.md
+++ b/cmd/repl/README.md
@@ -2,6 +2,9 @@
 
 A REPL CLI for interacting with the CQL engine. This can be a useful tool for quickly iterating while authoring CQL measures.
 
+**Warning: When using these tools with protected health information (PHI),
+please be sure to follow your organization's policies with respect to PHI.**
+
 ## Running
 
 To build the program from source run the following from the root of the


### PR DESCRIPTION
This change makes a couple README updates:
* Adds a CQL example snippet (we may want to update this a bit in the future)
* Simplifies / shortens "Getting Started" section. If we want, we can also add a couple commands to get started directly in the top level readme in the future.