### PR TITLE
Include Library in default ParsingError string

### DIFF
--- a/parser/errors.go
+++ b/parser/errors.go
@@ -33,7 +33,7 @@ type LibraryErrors struct {
 }
 
 func (le *LibraryErrors) Error() string {
-	var msgs []string
+	msgs := []string{fmt.Sprintf("error(s) in Library %q:", le.LibKey.String())}
 	for _, e := range le.Errors {
 		msgs = append(msgs, e.Error())
 	}

--- a/parser/errors_test.go
+++ b/parser/errors_test.go
@@ -69,7 +69,8 @@ func TestLibraryErrors(t *testing.T) {
 		t.Errorf("errors.Is(gotErr, ErrorBadFile) = false, want true")
 	}
 
-	wantErrorString := `1-1 first parsing error
+	wantErrorString := `error(s) in Library "TESTLIB 1.0.0":
+1-1 first parsing error
 2-2 second parsing error: bad file`
 	if gotErr.Error() != wantErrorString {
 		t.Errorf("gotErr.Error() = %q, want %q", gotErr.Error(), wantErrorString)


### PR DESCRIPTION
This includes Library information in the default ParsingError string. 