### PR TITLE
Evaluate FHIR.decimal.value directly to a System.Decimal

### DIFF
--- a/interpreter/operator_type.go
+++ b/interpreter/operator_type.go
@@ -248,15 +248,18 @@ func evalToDecimalString(m model.IUnaryExpression, opObj result.Value) (result.V
 	if err != nil {
 		return result.Value{}, err
 	}
+	return toDecimalFromString(op)
+}
 
+func toDecimalFromString(s string) (result.Value, error) {
 	// Check that the string meets the CQL decimal spec requirements.
-	found := decimalStringRegex.FindString(op)
-	if found == "" || found != op {
+	found := decimalStringRegex.FindString(s)
+	if found == "" || found != s {
 		return result.New(nil)
 	}
 
 	// ParseFloat works for every string that meets the CQL spec.
-	f, err := strconv.ParseFloat(op, 64)
+	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return result.Value{}, err
 	}

--- a/tests/enginetests/property_test.go
+++ b/tests/enginetests/property_test.go
@@ -339,6 +339,16 @@ func TestProperty(t *testing.T) {
 			wantResult: newOrFatal(t, result.Named{Value: &d4pb.String{Value: "obsValue"}, RuntimeType: &types.Named{TypeName: "FHIR.string"}}),
 		},
 		{
+			name: "FHIR.decimal.value returns a System.Decimal",
+			cql: dedent.Dedent(`
+					define FirstObservation: First([Observation])
+					define TESTRESULT: (FirstObservation.value as FHIR.Quantity).value.value`),
+			resources: []*r4pb.ContainedResource{
+				containedFromObservation(&r4observationpb.Observation{Value: &r4observationpb.Observation_ValueX{Choice: &r4observationpb.Observation_ValueX_Quantity{Quantity: &d4pb.Quantity{Value: &d4pb.Decimal{Value: "100.1"}}}}}),
+			},
+			wantResult: newOrFatal(t, 100.1),
+		},
+		{
 			name: "dateTime inside oneof returns dateTime proto",
 			cql: dedent.Dedent(`
 					define FirstObservation: First([Observation])


### PR DESCRIPTION
In the FHIR protos, `FHIR.decimal.value` is a string. However in the FHIR ModelInfo, `FHIR.decimal.value` is statically expected to evaluate directly to a System.Decimal, requiring us to bridge this gap directly during property computation. Interestingly, I found in an investigation that this is a major contributing factor to #59. 