### PR TITLE
Fix syntax error in CQL Playground HTML

### DIFF
--- a/cmd/cqlplay/static/index.html
+++ b/cmd/cqlplay/static/index.html
@@ -17,7 +17,7 @@
 <html>
 <meta charset="utf-8">
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css">
 


### PR DESCRIPTION
The syntax error of no closing arrow bracket in the <script> opening tag for the main Prism.js import has been fixed.

(In my browser, this error had invalidated the next <script> import of Prism's JSON language, and therefore caused the data editor to not be syntax highlighted, on Chromium 129.0.6668.42 and Firefox 130.0. Data is highlighted correctly after the PR is applied.)