### PR TITLE
Include expression name in eval errors

### DIFF
--- a/beam/main_test.go
+++ b/beam/main_test.go
@@ -110,7 +110,7 @@ func TestPipeline(t *testing.T) {
 			wantOutput: []*cbpb.BeamResult{},
 			wantError: []*cbpb.BeamError{
 				{
-					ErrorMessage: proto.String("failed during CQL evaluation: EvalTest 1.0, could not find ValueSet{urn:example:nosuchvalueset, } resource not loaded"),
+					ErrorMessage: proto.String("failed during CQL evaluation: EvalTest 1.0, failed to evaluate expression HasDiabetes: could not find ValueSet{urn:example:nosuchvalueset, } resource not loaded"),
 					SourceUri:    proto.String("bundle:bundle1"),
 				},
 			},

--- a/beam/transforms/eval_test.go
+++ b/beam/transforms/eval_test.go
@@ -160,7 +160,7 @@ func TestCQLEvalFn(t *testing.T) {
 			}`).GetBundle(),
 			wantError: []*cbpb.BeamError{
 				{
-					ErrorMessage: proto.String("failed during CQL evaluation: EvalTest 1.0, could not find ValueSet{urn:example:nosuchvalueset, } resource not loaded"),
+					ErrorMessage: proto.String("failed during CQL evaluation: EvalTest 1.0, failed to evaluate expression HasDiabetes: could not find ValueSet{urn:example:nosuchvalueset, } resource not loaded"),
 					SourceUri:    proto.String("bundle:bundle1"),
 				},
 			},

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -220,7 +220,7 @@ func (i *interpreter) evalLibrary(lib *model.Library, passedParams map[result.De
 			case *model.ExpressionDef:
 				res, err := i.evalExpression(s.GetExpression())
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to evaluate expression %s: %w", s.GetName(), err)
 				}
 				d := &reference.Def[result.Value]{
 					Name:             s.GetName(),


### PR DESCRIPTION
Adds expression name context to evaluation errors to aid debugging.