### PR TITLE
⚡ optimize slice growth in evalRetrieve

### DIFF
--- a/interpreter/expressions.go
+++ b/interpreter/expressions.go
@@ -191,7 +191,7 @@ func (i *interpreter) evalRetrieve(expr *model.Retrieve) (result.Value, error) {
 		return result.Value{}, fmt.Errorf("internal error - retrieve result type should be a list of named types, got %v", listResultType)
 	}
 
-	l := []result.Value{}
+	l := make([]result.Value, 0, len(got))
 	for _, c := range got {
 		r, err := unwrapContained(c)
 		if err != nil {


### PR DESCRIPTION
💡 **What:** This change optimizes the `evalRetrieve` function in `interpreter/expressions.go` by pre-allocating the slice used to collect retrieved values.

🎯 **Why:** Previously, the slice was initialized with zero capacity, causing it to undergo multiple reallocations and memory copies as it grew during the loop. By setting the initial capacity to the number of retrieved resources (`len(got)`), we ensure that at most one allocation occurs.

📊 **Measured Improvement:** While environmental limitations (slow dependency downloads in the sandbox) prevented me from obtaining exact benchmark numbers, this change follows Go performance best practices. It eliminates $O(\log n)$ reallocations and reduces overall memory pressure, which is particularly beneficial when retrieving a large number of resources.

---
*PR created automatically by Jules for task [4496038871358788997](https://jules.google.com/task/4496038871358788997) started by @suyashkumar*